### PR TITLE
fix: corrigir cálculo do crédito no valor total da usina

### DIFF
--- a/front/src/components/CalculoGeracao.vue
+++ b/front/src/components/CalculoGeracao.vue
@@ -428,8 +428,8 @@ export default {
 
       if (valor < media && reservaTotal > 0) {
         const faltante = media - valor;
-        const valorCredito = faltante * kwh;
-        return Math.min(valorCredito, reservaTotal);
+        const energiaCompensada = Math.min(faltante, reservaTotal);
+        return energiaCompensada * kwh;
       } else {
         return 0;
       }


### PR DESCRIPTION
O Math.min comparava o crédito em R$ com a reserva em kWh, misturando unidades. A energia compensada agora é limitada em kWh antes de ser convertida para R$.